### PR TITLE
updates for BootJS and custom JS/CSS

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -27,4 +27,11 @@
             {{- partial "foot.html" . -}}
         </div>
     </body>
+    {{ range .Params.js }}
+    <script src="{{ . }}"></script>
+    {{ end }}
+    <script src="https://kit.fontawesome.com/1b7478c139.js" crossorigin="anonymous"></script>
+    <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
 </html>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -24,6 +24,9 @@
 <!--My CSS-->
 <link rel="stylesheet" href="{{ "css/myscreen.css" | relURL }}" type="text/css" media="screen">
 <link rel="stylesheet" href="{{ "css/myprint.css" | relURL }}" type="text/css" media="print">
+{{ range .Params.css }}
+<link rel="stylesheet" type="text/css"  href="{{ . }}">
+{{ end }}
 <meta name="theme-color" content="black">
 {{- template "_internal/google_analytics_async.html" . }}
 


### PR DESCRIPTION
### baseof changes...
Added CDN refs for jQuery, popper and bootstrap JS so dynamic elements actually work
Also added a shortcode for pulling array values out of a page-level "js" attribute. 

### head changes
Similar to baseOf - added a short code that iterates through an array of page-level "css" attributes to load into an individual page context.

### sample page frontmatter
`js = ["/js/clpp.min.js", "/js/clpp_html5_mse_hls.plugin.min.js", "/js/clpp_common_abr.plugin.min.js", "/js/clpp_loggers.js", "/js/player.js"]`

`css = ["https://vjs.zencdn.net/5.16.0/video-js.css", "/css/clpp.css", "/css/v5style.css"]
`